### PR TITLE
ruisheng cao adds three entries in Exact Set Match on June 3rd, 2021

### DIFF
--- a/spider.md
+++ b/spider.md
@@ -288,6 +288,20 @@ redirect_from: "/seq2sql/spider"
                         <tr>
                            <td>
                               <p>1</p>
+                              <span class="date label label-default">Jun 1, 2021</span>
+                           </td>
+                           <td style="word-break:break-word;">
+                              LGESQL + ELECTRA (DB content used)
+                              <p class="institution">SJTU X-LANCE Lab & AISpeech</p>
+                              <a class="link" href="https://arxiv.org/abs/2106.01093">(Cao et al., ACL'21)</a>
+                              <a class="link" href="https://github.com/rhythmcao/text2sql-lgesql">code</a>
+                           </td>
+                           <td>75.1</td>
+                           <td><b>72.0</b></td>
+                        </tr>
+                        <tr>
+                           <td>
+                              <p>2</p>
                               <span class="date label label-default">Nov 19, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -296,11 +310,11 @@ redirect_from: "/seq2sql/spider"
                               <a class="link" href="http://arxiv.org/abs/2012.15355">(Xu et al., ACL'21)</a>
                            </td>
                            <td>75.0</td>
-                           <td><b>70.9</b></td>
+                           <td>70.9</td>
                         </tr>
                         <tr>
                            <td>
-                              <p>2</p>
+                              <p>3</p>
                               <span class="date label label-default">Nov 19, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -312,7 +326,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>3</p>
+                              <p>4</p>
                               <span class="date label label-default">Nov 19, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -324,7 +338,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>4</p>
+                              <p>5</p>
                               <span class="date label label-default">Dec 25, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -337,7 +351,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>4</p>
+                              <p>5</p>
                               <span class="date label label-default">Sep 08, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -351,7 +365,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>4</p>
+                              <p>5</p>
                               <span class="date label label-default">Aug 18, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -365,7 +379,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>4</p>
+                              <p>5</p>
                               <span class="date label label-default">Mar 10, 2021</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -379,7 +393,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>7</p>
+                              <p>9</p>
                               <span class="date label label-default">Nov 20, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -392,7 +406,21 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>8</p>
+                              <p>9</p>
+                              <span class="date label label-default">Jun 1, 2021</span>
+                           </td>
+                           <td style="word-break:break-word;">
+                              LGESQL + BERT (DB content used)
+                              <p class="institution">SJTU X-LANCE Lab & AISpeech</p>
+                              <a class="link" href="https://arxiv.org/abs/2106.01093">(Cao et al., ACL'21)</a>
+                              <a class="link" href="https://github.com/rhythmcao/text2sql-lgesql">code</a>
+                           </td>
+                           <td>74.1</td>
+                           <td>68.3</td>
+                        </tr>
+                        <tr>
+                           <td>
+                              <p>11</p>
                               <span class="date label label-default">Jan 16, 2021</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -405,7 +433,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>9</p>
+                              <p>12</p>
                               <span class="date label label-default">Nov 24, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -419,7 +447,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>10</p>
+                              <p>13</p>
                               <span class="date label label-default">Sep. 8, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -432,7 +460,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>11</p>
+                              <p>14</p>
                               <span class="date label label-default">May 02, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -446,7 +474,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>12</p>
+                              <p>15</p>
                               <span class="date label label-default">Dec. 07, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -458,7 +486,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>13</p>
+                              <p>16</p>
                               <span class="date label label-default">Sep. 8, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -470,7 +498,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>14</p>
+                              <p>17</p>
                               <span class="date label label-default">Nov 24, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -484,7 +512,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>15</p>
+                              <p>18</p>
                               <span class="date label label-default">Sep. 8, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -496,7 +524,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>15</p>
+                              <p>18</p>
                               <span class="date label label-default">Nov. 25, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -508,7 +536,21 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>16</p>
+                              <p>20</p>
+                              <span class="date label label-default">Feb 2, 2021</span>
+                           </td>
+                           <td style="word-break:break-word;">
+                              LGESQL + GLOVE (DB content used)
+                              <p class="institution">SJTU X-LANCE Lab & AISpeech</p>
+                              <a class="link" href="https://arxiv.org/abs/2106.01093">(Cao et al., ACL'21)</a>
+                              <a class="link" href="https://github.com/rhythmcao/text2sql-lgesql">code</a>
+                           </td>
+                           <td>67.6</td>
+                           <td>62.8</td>
+                        </tr>
+                        <tr>
+                           <td>
+                              <p>21</p>
                               <span class="date label label-default">May 31, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -520,7 +562,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>17</p>
+                              <p>22</p>
                               <span class="date label label-default">Dec 13, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -534,7 +576,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>18</p>
+                              <p>23</p>
                               <span class="date label label-default">May 31, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -546,7 +588,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>19</p>
+                              <p>24</p>
                               <span class="date label label-default">Feb 18, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -559,7 +601,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>19</p>
+                              <p>24</p>
                               <span class="date label label-default">Oct 19, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -572,7 +614,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>21</p>
+                              <p>26</p>
                               <span class="date label label-default">Dec 18, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -584,7 +626,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>22</p>
+                              <p>27</p>
                               <span class="date label label-default">May 30, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -598,7 +640,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>23</p>
+                              <p>28</p>
                               <span class="date label label-default">Nov 12, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -611,7 +653,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>24</p>
+                              <p>29</p>
                               <span class="date label label-default">Dec 13, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -625,7 +667,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>25</p>
+                              <p>30</p>
                               <span class="date label label-default">Dec 13, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -639,7 +681,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>26</p>
+                              <p>31</p>
                               <span class="date label label-default">Dec 13, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -651,7 +693,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>27</p>
+                              <p>32</p>
                               <span class="date label label-default">June 24, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -663,7 +705,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>28</p>
+                              <p>33</p>
                               <span class="date label label-default">Sep 20, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -675,7 +717,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>28</p>
+                              <p>33</p>
                               <span class="date label label-default">May 19, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -689,7 +731,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>30</p>
+                              <p>35</p>
                               <span class="date label label-default">Nov 4, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -703,7 +745,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>31</p>
+                              <p>36</p>
                               <span class="date label label-default">Apr 8, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -715,7 +757,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>32</p>
+                              <p>37</p>
                               <span class="date label label-default">Sep 19, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -727,7 +769,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>33</p>
+                              <p>38</p>
                               <span class="date label label-default">Sep 1, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -741,7 +783,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>33</p>
+                              <p>39</p>
                               <span class="date label label-default">May 21, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -754,7 +796,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>35</p>
+                              <p>39</p>
                               <span class="date label label-default">May 21, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -766,7 +808,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>36</p>
+                              <p>41</p>
                               <span class="date label label-default">May 28, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -778,7 +820,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>37</p>
+                              <p>42</p>
                               <span class="date label label-default">June 24, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -790,7 +832,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>38</p>
+                              <p>43</p>
                               <span class="date label label-default">Aug 30, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -804,7 +846,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>39</p>
+                              <p>44</p>
                               <span class="date label label-default">Dec 13, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -816,7 +858,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>39</p>
+                              <p>44</p>
                               <span class="date label label-default">Apr 5, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -828,7 +870,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>41</p>
+                              <p>46</p>
                               <span class="date label label-default">May 19, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -842,7 +884,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>41</p>
+                              <p>46</p>
                               <span class="date label label-default">Mar 17, 2020</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -854,7 +896,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>43</p>
+                              <p>48</p>
                               <span class="date label label-default">Dec 13, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -866,7 +908,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>44</p>
+                              <p>49</p>
                               <span class="date label label-default">June 11, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -878,7 +920,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>45</p>
+                              <p>50</p>
                               <span class="date label label-default">June 12, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -890,7 +932,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>46</p>
+                              <p>51</p>
                               <span class="date label label-default">Aug 31, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -902,7 +944,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>47</p>
+                              <p>52</p>
                               <span class="date label label-default">May 16, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -916,7 +958,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>48</p>
+                              <p>53</p>
                               <span class="date label label-default">Feb 25, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -928,7 +970,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>49</p>
+                              <p>54</p>
                               <span class="date label label-default">May 30, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -941,7 +983,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>50</p>
+                              <p>55</p>
                               <span class="date label label-default">Sep 1, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -955,7 +997,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>51</p>
+                              <p>56</p>
                               <span class="date label label-default">Dec 13, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -967,7 +1009,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>52</p>
+                              <p>57</p>
                               <span class="date label label-default">Sep 20, 2018</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -981,7 +1023,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>53</p>
+                              <p>58</p>
                               <span class="date label label-default">April 18, 2019</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -994,7 +1036,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>54</p>
+                              <p>59</p>
                               <span class="date label label-default">Sep 20, 2018</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -1008,7 +1050,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>55</p>
+                              <p>60</p>
                               <span class="date label label-default">Sep 20, 2018</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -1022,7 +1064,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>56</p>
+                              <p>61</p>
                               <span class="date label label-default">Sep 20, 2018</span>
                            </td>
                            <td style="word-break:break-word;">
@@ -1036,7 +1078,7 @@ redirect_from: "/seq2sql/spider"
                         </tr>
                         <tr>
                            <td>
-                              <p>57</p>
+                              <p>62</p>
                               <span class="date label label-default">Sep 20, 2018</span>
                            </td>
                            <td style="word-break:break-word;">


### PR DESCRIPTION
1. Ruisheng Cao adds three entries on Exact Set Match partition on June 3rd, 2021
Feb 2, 2021  LGESQL + GLOVE (DB content used)  dev: 67.6  test: 62.8
Jun 1, 2021  LGESQL + BERT (DB content used)  dev: 74.1  test: 68.3
Jun 1, 2021  LGESQL + ELECTRA (DB content used)  dev: 75.1  test: 72.0

2. Also fix two ranking errors (both ignore the situation where a tie occurs)
RAT-SQL + STRUG (DB content used) ranked 7
AuxNet + BART (DB content used) ranked 16
Thus, the total number of indexes increase from 57 to 62
